### PR TITLE
updates to COUNTY and DATETIME providers

### DIFF
--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/DateTimeMaskingProvider.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/DateTimeMaskingProvider.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -103,21 +103,17 @@ public class DateTimeMaskingProvider extends AbstractMaskingProvider {
   private final String dateYearDeleteComparedValue;
   private final int unspecifiedValueHandling;
   private final String unspecifiedValueReturnMessage;
-
-  private DateTimeFormatter fixedDateFormat = null;
+  private final DateTimeFormatter fixedDateFormat;
 
   public DateTimeMaskingProvider(DateTimeMaskingProviderConfig configuration) {
     String fixedDateFormatString = configuration.getFormatFixed();
-
-    if (fixedDateFormatString != null) {
-      fixedDateFormat = new DateTimeFormatterBuilder().appendPattern(fixedDateFormatString)
-          .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
-          .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
-          .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter();
-
-    } else {
-      this.fixedDateFormat = null;
-    }
+    this.fixedDateFormat =
+        (fixedDateFormatString != null && !fixedDateFormatString.trim().isEmpty())
+            ? new DateTimeFormatterBuilder().appendPattern(fixedDateFormatString)
+                .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+                .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+                .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter()
+            : null;
 
     this.shiftDate = configuration.isMaskShiftDate();
     this.shiftSeconds = configuration.getMaskShiftSeconds();
@@ -201,17 +197,15 @@ public class DateTimeMaskingProvider extends AbstractMaskingProvider {
     this.dateYearDeleteComparedValue = compareDateValue;
 
     DateTimeMaskingProviderConfig configuration = new DateTimeMaskingProviderConfig();
+    
     String fixedDateFormatString = configuration.getFormatFixed();
-
-    if (fixedDateFormatString != null) {
-      fixedDateFormat = new DateTimeFormatterBuilder().appendPattern(fixedDateFormatString)
-          .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
-          .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
-          .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter();
-
-    } else {
-      this.fixedDateFormat = null;
-    }
+    this.fixedDateFormat =
+        (fixedDateFormatString != null && !fixedDateFormatString.trim().isEmpty())
+            ? new DateTimeFormatterBuilder().appendPattern(fixedDateFormatString)
+                .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+                .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+                .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter()
+            : null;
 
     this.shiftDate = configuration.isMaskShiftDate();
     this.shiftSeconds = configuration.getMaskShiftSeconds();

--- a/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/CountyMaskingProviderTest.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/CountyMaskingProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,6 +14,7 @@ import org.junit.Test;
 import com.ibm.whc.deid.providers.identifiers.CountyIdentifier;
 import com.ibm.whc.deid.providers.identifiers.Identifier;
 import com.ibm.whc.deid.shared.pojo.config.masking.CountyMaskingProviderConfig;
+import com.ibm.whc.deid.shared.pojo.masking.MaskingProviderType;
 
 public class CountyMaskingProviderTest extends TestLogSetUp implements MaskingProviderTest {
   /*
@@ -22,6 +23,7 @@ public class CountyMaskingProviderTest extends TestLogSetUp implements MaskingPr
   @Test
   public void testPseudorandom() throws Exception {
     CountyMaskingProviderConfig configuration = new CountyMaskingProviderConfig();
+    assertEquals(MaskingProviderType.COUNTY, configuration.getType());
     configuration.setMaskPseudorandom(true);
 
     MaskingProvider maskingProvider = new CountyMaskingProvider(configuration, tenantId);
@@ -43,6 +45,7 @@ public class CountyMaskingProviderTest extends TestLogSetUp implements MaskingPr
     // county.mask.pseudorandom by default is off
     Identifier identifier = new CountyIdentifier();
     CountyMaskingProviderConfig configuration = new CountyMaskingProviderConfig();
+    assertEquals(MaskingProviderType.COUNTY, configuration.getType());
 
     MaskingProvider maskingProvider = new CountyMaskingProvider(configuration, tenantId);
 

--- a/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/DateTimeMaskingProviderTest.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/DateTimeMaskingProviderTest.java
@@ -103,6 +103,7 @@ public class DateTimeMaskingProviderTest extends TestLogSetUp {
   public void testMaskShiftDateNegative() throws Exception {
 
     DateTimeMaskingProviderConfig config = new DateTimeMaskingProviderConfig();
+    config.setFormatFixed("  \t\n  ");  // whitespace, so ignored
     config.setMaskShiftDate(true);
     config.setMaskShiftSeconds(-120);
     DateTimeMaskingProvider maskingProvider = new DateTimeMaskingProvider(config);
@@ -110,8 +111,6 @@ public class DateTimeMaskingProviderTest extends TestLogSetUp {
     // different values
     String originalDateTime = "08-12-1981 00:04:00";
     String maskedDateTime = maskingProvider.mask(originalDateTime);
-    assertFalse(originalDateTime.equals(maskedDateTime));
-
     assertEquals("08-12-1981 00:02:00", maskedDateTime);
   }
 

--- a/whc-shared/src/main/java/com/ibm/whc/deid/shared/pojo/config/masking/CountyMaskingProviderConfig.java
+++ b/whc-shared/src/main/java/com/ibm/whc/deid/shared/pojo/config/masking/CountyMaskingProviderConfig.java
@@ -18,7 +18,7 @@ public class CountyMaskingProviderConfig extends MaskingProviderConfig {
   boolean maskPseudorandom = false;
 
   public CountyMaskingProviderConfig() {
-    type = MaskingProviderType.CITY;
+    type = MaskingProviderType.COUNTY;
   }
 
   public boolean isMaskPseudorandom() {


### PR DESCRIPTION
Correct deserialization issue with COUNTY provider.
Equate an empty string to null for the fixed format parameter on the DATETIME provider.  Allows default formats to be used.