### PR TITLE
Jra m 1191 etest

### DIFF
--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/DateTimeConsistentShiftMaskingProvider.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/DateTimeConsistentShiftMaskingProvider.java
@@ -215,7 +215,7 @@ public class DateTimeConsistentShiftMaskingProvider extends AbstractMaskingProvi
     // determine the total number of eligible numbers of days based on the configuration
     int rangeLength = this.dateShiftMaximumDays - this.dateShiftMinimumDays + 1;
     int numberOfPossibleShiftValues = rangeLength;
-    if (this.dateShiftDirection == DateShiftDirection.beforeOrAfter) {
+    if (this.dateShiftDirection == DateShiftDirection.BEFORE_OR_AFTER) {
       numberOfPossibleShiftValues *= 2;
       if (this.dateShiftMinimumDays == 0) {
         numberOfPossibleShiftValues--; // don't add 0 twice
@@ -229,10 +229,10 @@ public class DateTimeConsistentShiftMaskingProvider extends AbstractMaskingProvi
     // get the value at the index into the total possible values
     int shfitNumberOfDays = -1;
     switch (this.dateShiftDirection) {
-      case before:
+      case BEFORE:
         shfitNumberOfDays = -this.dateShiftMaximumDays + possiblesIndex;
         break;
-      case after:
+      case AFTER:
         shfitNumberOfDays = this.dateShiftMinimumDays + possiblesIndex;
         break;
       default:

--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/DateTimeConsistentShiftMaskingProvider.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/DateTimeConsistentShiftMaskingProvider.java
@@ -57,14 +57,26 @@ public class DateTimeConsistentShiftMaskingProvider extends AbstractMaskingProvi
 
   protected class ParseResponse {
 
-    public DateTimeFormatter formatter;
-    public String format;
-    public TemporalAccessor temporal;
+    private DateTimeFormatter formatter;
+    private String format;
+    private TemporalAccessor temporal;
 
     protected ParseResponse(DateTimeFormatter formatter, String format, TemporalAccessor temporal) {
       this.formatter = formatter;
       this.format = format;
       this.temporal = temporal;
+    }
+
+    public DateTimeFormatter getFormatter() {
+      return formatter;
+    }
+
+    public String getFormat() {
+      return format;
+    }
+
+    public TemporalAccessor getTemporalAccessor() {
+      return temporal;
     }
   }
 
@@ -303,13 +315,13 @@ public class DateTimeConsistentShiftMaskingProvider extends AbstractMaskingProvi
     if (parseResponse == null) {
       return applyUnexpectedValueHandling(originalValue, null);
     }
-    DateTimeFormatter formatter = parseResponse.formatter;
-    TemporalAccessor parsedOriginal = parseResponse.temporal;
+    DateTimeFormatter formatter = parseResponse.getFormatter();
+    TemporalAccessor parsedOriginal = parseResponse.getTemporalAccessor();
 
     Temporal adjustedTemporal = adjust(parsedOriginal, offsetDays);
     if (adjustedTemporal == null) {
       // should only happen for custom formatters
-      throw new BadFormatterException(parseResponse.format);
+      throw new BadFormatterException(parseResponse.getFormat());
     }
 
     String replacement = formatter.format(adjustedTemporal);

--- a/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/DateTimeConsistentShiftMaskingProviderTest.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/DateTimeConsistentShiftMaskingProviderTest.java
@@ -253,7 +253,7 @@ public class DateTimeConsistentShiftMaskingProviderTest implements MaskingProvid
     DateTimeConsistentShiftMaskingProviderConfig config =
         new DateTimeConsistentShiftMaskingProviderConfig();
     config.setPatientIdentifierPath("/id");
-    config.setDateShiftDirection(DateShiftDirection.before);
+    config.setDateShiftDirection(DateShiftDirection.BEFORE);
     config.setDateShiftMinimumDays(1);
     config.setDateShiftMaximumDays(10);
     TestDateTimeConsistentShiftMaskingProvider provider =
@@ -298,7 +298,7 @@ public class DateTimeConsistentShiftMaskingProviderTest implements MaskingProvid
     DateTimeConsistentShiftMaskingProviderConfig config =
         new DateTimeConsistentShiftMaskingProviderConfig();
     config.setPatientIdentifierPath("/id");
-    config.setDateShiftDirection(DateShiftDirection.after);
+    config.setDateShiftDirection(DateShiftDirection.AFTER);
     config.setDateShiftMinimumDays(1);
     config.setDateShiftMaximumDays(10);
     TestDateTimeConsistentShiftMaskingProvider provider =
@@ -343,7 +343,7 @@ public class DateTimeConsistentShiftMaskingProviderTest implements MaskingProvid
     DateTimeConsistentShiftMaskingProviderConfig config =
         new DateTimeConsistentShiftMaskingProviderConfig();
     config.setPatientIdentifierPath("/id");
-    config.setDateShiftDirection(DateShiftDirection.beforeOrAfter);
+    config.setDateShiftDirection(DateShiftDirection.BEFORE_OR_AFTER);
     config.setDateShiftMinimumDays(1);
     config.setDateShiftMaximumDays(10);
     TestDateTimeConsistentShiftMaskingProvider provider =
@@ -536,7 +536,7 @@ public class DateTimeConsistentShiftMaskingProviderTest implements MaskingProvid
         new DateTimeConsistentShiftMaskingProviderConfig();
     config.setUnexpectedInputHandling(UnexpectedMaskingInputHandler.ERROR_EXIT);
     config.setPatientIdentifierPath("/a");
-    config.setDateShiftDirection(DateShiftDirection.after);
+    config.setDateShiftDirection(DateShiftDirection.AFTER);
     config.setDateShiftMinimumDays(2);
     config.setDateShiftMaximumDays(5);
     DateTimeConsistentShiftMaskingProvider provider =

--- a/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/DateTimeConsistentShiftMaskingProviderTest.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/DateTimeConsistentShiftMaskingProviderTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.ibm.whc.deid.ObjectMapperFactory;
+import com.ibm.whc.deid.providers.masking.DateTimeConsistentShiftMaskingProvider.BadFormatterException;
 import com.ibm.whc.deid.providers.masking.fhir.MaskingActionInputIdentifier;
 import com.ibm.whc.deid.shared.pojo.config.masking.DateTimeConsistentShiftMaskingProviderConfig;
 import com.ibm.whc.deid.shared.pojo.config.masking.DateTimeConsistentShiftMaskingProviderConfig.DateShiftDirection;
@@ -72,94 +73,97 @@ public class DateTimeConsistentShiftMaskingProviderTest implements MaskingProvid
   private void verifyStandardReplacements(DateTimeConsistentShiftMaskingProvider provider,
       String badInputValue) {
 
-    assertEquals(badInputValue, provider.applyOffsetAndReformat("value-abc", 24));
-    assertEquals(badInputValue, provider.applyOffsetAndReformat("", 24));
-    assertEquals(badInputValue, provider.applyOffsetAndReformat("13", 24));
+    assertEquals(badInputValue, provider.applyOffsetAndReformat("value-abc", 24, null));
+    assertEquals(badInputValue, provider.applyOffsetAndReformat("", 24, null));
+    assertEquals(badInputValue, provider.applyOffsetAndReformat("13", 24, null));
 
     assertEquals("2020-02-29T01:02:03+10:30",
-        provider.applyOffsetAndReformat("2021-03-01T01:02:03+10:30", -366));
+        provider.applyOffsetAndReformat("2021-03-01T01:02:03+10:30", -366, null));
     assertEquals("2020-02-29T14:16:18+10:30",
-        provider.applyOffsetAndReformat("2019-02-28T14:16:18+10:30", 366));
+        provider.applyOffsetAndReformat("2019-02-28T14:16:18+10:30", 366, null));
     assertEquals("2020-02-29T01:02:03Z",
-        provider.applyOffsetAndReformat("2020-03-01T01:02:03Z", -1));
+        provider.applyOffsetAndReformat("2020-03-01T01:02:03Z", -1, null));
     assertEquals("2020-10-31T15:16:17-05:00",
-        provider.applyOffsetAndReformat("2020-11-01T15:16:17-05:00", -1));
+        provider.applyOffsetAndReformat("2020-11-01T15:16:17-05:00", -1, null));
     assertEquals("2020-10-31T02:04:06-05:00",
-        provider.applyOffsetAndReformat("2020-11-01T02:04:06-05:00", -1));
+        provider.applyOffsetAndReformat("2020-11-01T02:04:06-05:00", -1, null));
     assertEquals("2020-10-31T01:03:05-05:00",
-        provider.applyOffsetAndReformat("2020-11-01T01:03:05-05:00", -1));
+        provider.applyOffsetAndReformat("2020-11-01T01:03:05-05:00", -1, null));
     assertEquals("2020-03-08T01:10:20-05:00",
-        provider.applyOffsetAndReformat("2020-03-09T01:10:20-05:00", -1));
+        provider.applyOffsetAndReformat("2020-03-09T01:10:20-05:00", -1, null));
     assertEquals("2020-03-08T02:10:20-05:00",
-        provider.applyOffsetAndReformat("2020-03-09T02:10:20-05:00", -1));
+        provider.applyOffsetAndReformat("2020-03-09T02:10:20-05:00", -1, null));
     assertEquals("2020-03-08T03:10:20-05:00",
-        provider.applyOffsetAndReformat("2020-03-11T03:10:20-05:00", -3));
+        provider.applyOffsetAndReformat("2020-03-11T03:10:20-05:00", -3, null));
     assertEquals("2020-03-08T02:03:04-05:00",
-        provider.applyOffsetAndReformat("2020-03-09T02:03:04-05:00", -1));
+        provider.applyOffsetAndReformat("2020-03-09T02:03:04-05:00", -1, null));
     assertEquals("2020-02-29T01:02:03-01:00",
-        provider.applyOffsetAndReformat("2020-03-01T01:02:03-01:00", -1));
+        provider.applyOffsetAndReformat("2020-03-01T01:02:03-01:00", -1, null));
     assertEquals("2020-02-29T01:02:03-01:00",
-        provider.applyOffsetAndReformat("2020-03-01T01:02:03-01:00", -1));
+        provider.applyOffsetAndReformat("2020-03-01T01:02:03-01:00", -1, null));
     assertEquals("2020-02-29T01:02:03-01:00",
-        provider.applyOffsetAndReformat("2020-03-01T01:02:03-01:00", -1));
+        provider.applyOffsetAndReformat("2020-03-01T01:02:03-01:00", -1, null));
     assertEquals("2020-02-29T01:02:00-01:00",
-        provider.applyOffsetAndReformat("2020-03-01T01:02-01:00", -1));
+        provider.applyOffsetAndReformat("2020-03-01T01:02-01:00", -1, null));
     assertEquals("2019-12-29T01:02:03+03:00",
-        provider.applyOffsetAndReformat("2020-03-01T01:02:03+03:00", -63));
+        provider.applyOffsetAndReformat("2020-03-01T01:02:03+03:00", -63, null));
 
-    assertEquals(badInputValue, provider.applyOffsetAndReformat("2020-03-01T01-01:00", -1));
-    assertEquals(badInputValue, provider.applyOffsetAndReformat("2020-03-01T01:-01:00", -1));
+    assertEquals(badInputValue, provider.applyOffsetAndReformat("2020-03-01T01-01:00", -1, null));
+    assertEquals(badInputValue, provider.applyOffsetAndReformat("2020-03-01T01:-01:00", -1, null));
 
     // offset is not optional in builtin ISO pattern
-    assertEquals(badInputValue, provider.applyOffsetAndReformat("2020-03-01T01:02:03", -1));
+    assertEquals(badInputValue, provider.applyOffsetAndReformat("2020-03-01T01:02:03", -1, null));
 
-    assertEquals("2020-02-29", provider.applyOffsetAndReformat("2020-03-01", -1));
-    assertEquals("2020-01-03", provider.applyOffsetAndReformat("2020-01-03", 0));
-    assertEquals("2019-12-24", provider.applyOffsetAndReformat("2020-01-03", -10));
-    assertEquals("2019-12-31", provider.applyOffsetAndReformat("2020-03-01", -61));
-    assertEquals("2020-01-03", provider.applyOffsetAndReformat("2019-12-24", 10));
-    assertEquals("2020-03-01", provider.applyOffsetAndReformat("2019-12-31", 61));
+    assertEquals("2020-02-29", provider.applyOffsetAndReformat("2020-03-01", -1, null));
+    assertEquals("2020-01-03", provider.applyOffsetAndReformat("2020-01-03", 0, null));
+    assertEquals("2019-12-24", provider.applyOffsetAndReformat("2020-01-03", -10, null));
+    assertEquals("2019-12-31", provider.applyOffsetAndReformat("2020-03-01", -61, null));
+    assertEquals("2020-01-03", provider.applyOffsetAndReformat("2019-12-24", 10, null));
+    assertEquals("2020-03-01", provider.applyOffsetAndReformat("2019-12-31", 61, null));
 
-    assertEquals("2020/02/29", provider.applyOffsetAndReformat("2020/03/01", -1));
-    assertEquals("2020/01/03", provider.applyOffsetAndReformat("2020/01/03", 0));
-    assertEquals("2019/12/24", provider.applyOffsetAndReformat("2020/01/03", -10));
-    assertEquals("2019/12/31", provider.applyOffsetAndReformat("2020/03/01", -61));
-    assertEquals("2020/01/03", provider.applyOffsetAndReformat("2019/12/24", 10));
-    assertEquals("2020/03/01", provider.applyOffsetAndReformat("2019/12/31", 61));
+    assertEquals("2020/02/29", provider.applyOffsetAndReformat("2020/03/01", -1, null));
+    assertEquals("2020/01/03", provider.applyOffsetAndReformat("2020/01/03", 0, null));
+    assertEquals("2019/12/24", provider.applyOffsetAndReformat("2020/01/03", -10, null));
+    assertEquals("2019/12/31", provider.applyOffsetAndReformat("2020/03/01", -61, null));
+    assertEquals("2020/01/03", provider.applyOffsetAndReformat("2019/12/24", 10, null));
+    assertEquals("2020/03/01", provider.applyOffsetAndReformat("2019/12/31", 61, null));
 
-    assertEquals("2020-02-29 13:14:15", provider.applyOffsetAndReformat("2020-03-02 13:14:15", -2));
-    assertEquals("2020-02-29 13:14:15", provider.applyOffsetAndReformat("2020-03-01 13:14:15", -1));
-    assertEquals("2020-02-29 13:14:15", provider.applyOffsetAndReformat("2019-12-31 13:14:15", 60));
+    assertEquals("2020-02-29 13:14:15",
+        provider.applyOffsetAndReformat("2020-03-02 13:14:15", -2, null));
+    assertEquals("2020-02-29 13:14:15",
+        provider.applyOffsetAndReformat("2020-03-01 13:14:15", -1, null));
+    assertEquals("2020-02-29 13:14:15",
+        provider.applyOffsetAndReformat("2019-12-31 13:14:15", 60, null));
 
-    assertEquals(badInputValue, provider.applyOffsetAndReformat("2020-03-01 3:4:5", -1));
+    assertEquals(badInputValue, provider.applyOffsetAndReformat("2020-03-01 3:4:5", -1, null));
 
-    assertEquals("2020/02/29 13:14:15", provider.applyOffsetAndReformat("2020/02/19 13:14:15", 10));
     assertEquals("2020/02/29 13:14:15",
-        provider.applyOffsetAndReformat("2020/03/10 13:14:15", -10));
+        provider.applyOffsetAndReformat("2020/02/19 13:14:15", 10, null));
+    assertEquals("2020/02/29 13:14:15",
+        provider.applyOffsetAndReformat("2020/03/10 13:14:15", -10, null));
 
-    assertEquals(badInputValue, provider.applyOffsetAndReformat("2020/03/01 3:4:5", -1));
+    assertEquals(badInputValue, provider.applyOffsetAndReformat("2020/03/01 3:4:5", -1, null));
 
-    assertEquals("16/04/1967", provider.applyOffsetAndReformat("16/04/1965", 730));
-    assertEquals("16-04-1967", provider.applyOffsetAndReformat("16-04-1968", -366));
+    assertEquals("16/04/1967", provider.applyOffsetAndReformat("16/04/1965", 730, null));
+    assertEquals("16-04-1967", provider.applyOffsetAndReformat("16-04-1968", -366, null));
     assertEquals("16/04/1967 13:14:15",
-        provider.applyOffsetAndReformat("16/04/1965 13:14:15", 730));
+        provider.applyOffsetAndReformat("16/04/1965 13:14:15", 730, null));
     assertEquals("16-04-1967 02:04:06",
-        provider.applyOffsetAndReformat("16-04-1968 02:04:06", -366));
+        provider.applyOffsetAndReformat("16-04-1968 02:04:06", -366, null));
 
-    assertEquals(badInputValue, provider.applyOffsetAndReformat("04-16-1967", 1));
-    assertEquals(badInputValue, provider.applyOffsetAndReformat("16-04-1967 14:16", 1));
-    assertEquals(badInputValue, provider.applyOffsetAndReformat("04/16/1967", 1));
-    assertEquals(badInputValue, provider.applyOffsetAndReformat("16/04/1967 14", 1));
+    assertEquals(badInputValue, provider.applyOffsetAndReformat("04-16-1967", 1, null));
+    assertEquals(badInputValue, provider.applyOffsetAndReformat("16-04-1967 14:16", 1, null));
+    assertEquals(badInputValue, provider.applyOffsetAndReformat("04/16/1967", 1, null));
+    assertEquals(badInputValue, provider.applyOffsetAndReformat("16/04/1967 14", 1, null));
 
-    assertEquals("01-May-1967", provider.applyOffsetAndReformat("29-apr-1967", 2));
-    assertEquals("01-Jun-1967", provider.applyOffsetAndReformat("29-APR-1967", 33));
+    assertEquals("01-May-1967", provider.applyOffsetAndReformat("29-apr-1967", 2, null));
+    assertEquals("01-Jun-1967", provider.applyOffsetAndReformat("29-APR-1967", 33, null));
 
-    assertEquals(badInputValue, provider.applyOffsetAndReformat("29-apx-1967", 33));
+    assertEquals(badInputValue, provider.applyOffsetAndReformat("29-apx-1967", 33, null));
   }
 
   @Test
   public void testApplyOffsetAndReformat_custom() {
-    System.out.println(DateTimeFormatter.ISO_ZONED_DATE_TIME.toString());
     DateTimeConsistentShiftMaskingProviderConfig config =
         new DateTimeConsistentShiftMaskingProviderConfig();
     config.setPatientIdentifierPath("/id");
@@ -173,41 +177,75 @@ public class DateTimeConsistentShiftMaskingProviderTest implements MaskingProvid
 
     verifyStandardReplacements(provider, "Bad");
 
+    List<DateTimeFormatter> customFormatters = provider.buildCustomFormatters();
+
     // ---------------------------------------------------------------------------
     // 08 MAR 2020 is start of daylight savings time in America/Chicago (CST/CDT)
     // 01 NOV 2020 is end of daylight savings time in America/Chicago (CST/CDT)
     // ---------------------------------------------------------------------------
 
     // input offset overridden by zone id when both supplied
-    assertEquals("2020-10-31T05:06:07-05:00[America/Chicago]",
-        provider.applyOffsetAndReformat("2020-11-01T05:06:07+10:00[America/Chicago]", -1));
+    assertEquals("2020-10-31T05:06:07-05:00[America/Chicago]", provider.applyOffsetAndReformat(
+        "2020-11-01T05:06:07+10:00[America/Chicago]", -1, customFormatters));
     assertEquals("2020-11-01T01:06:07-06:00[America/Chicago]",
-        provider.applyOffsetAndReformat("2020-11-04T01:06:07-08:00[America/Chicago]", -3));
+        provider.applyOffsetAndReformat("2020-11-04T01:06:07-08:00[America/Chicago]", -3,
+            customFormatters));
     assertEquals("2020-11-01T01:06:07-05:00[America/Chicago]",
-        provider.applyOffsetAndReformat("2020-10-27T01:06:07-08:00[America/Chicago]", 5));
+        provider.applyOffsetAndReformat("2020-10-27T01:06:07-08:00[America/Chicago]", 5,
+            customFormatters));
     assertEquals("2020-11-01T02:06:07-06:00[America/Chicago]",
-        provider.applyOffsetAndReformat("2020-10-27T02:06:07-08:00[America/Chicago]", 5));
+        provider.applyOffsetAndReformat("2020-10-27T02:06:07-08:00[America/Chicago]", 5,
+            customFormatters));
     assertEquals("2020-05-01T13:14:15-05:00[America/Chicago]",
-        provider.applyOffsetAndReformat("2020-04-01T13:14:15-05:00[America/Chicago]", 30));
+        provider.applyOffsetAndReformat("2020-04-01T13:14:15-05:00[America/Chicago]", 30,
+            customFormatters));
 
     assertEquals("2020-10-31T05:06:07 CDT",
-        provider.applyOffsetAndReformat("2020-11-01T05:06:07 CDT", -1));
+        provider.applyOffsetAndReformat("2020-11-01T05:06:07 CDT", -1, customFormatters));
     // pattern is for short zone name
     assertEquals("2020-11-03T05:06:07 CST",
-        provider.applyOffsetAndReformat("2020-11-01T05:06:07 America/Chicago", 2));
+        provider.applyOffsetAndReformat("2020-11-01T05:06:07 America/Chicago", 2,
+            customFormatters));
     // target day is 23 hours
     assertEquals("2020-03-08T03:03:04 CDT",
-        provider.applyOffsetAndReformat("2020-03-11T02:03:04 CDT", -3));
+        provider.applyOffsetAndReformat("2020-03-11T02:03:04 CDT", -3, customFormatters));
     // target day is 23 hours
     assertEquals("2020-03-08T01:03:04 CST",
-        provider.applyOffsetAndReformat("2020-03-01T02:03:04 America/Chicago", 7));
+        provider.applyOffsetAndReformat("2020-03-01T02:03:04 America/Chicago", 7,
+            customFormatters));
     // target day is 23 hours, but target hour exists
     assertEquals("2020-03-08T14:03:04 CDT",
-        provider.applyOffsetAndReformat("2020-03-01T14:03:04 America/Chicago", 7));
+        provider.applyOffsetAndReformat("2020-03-01T14:03:04 America/Chicago", 7,
+            customFormatters));
 
-    assertEquals("99355", provider.applyOffsetAndReformat("99365", -10));
-    assertEquals("98365", provider.applyOffsetAndReformat("99365", -365));
-    assertEquals("00001", provider.applyOffsetAndReformat("99365", 1));
+    assertEquals("99355", provider.applyOffsetAndReformat("99365", -10, customFormatters));
+    assertEquals("98365", provider.applyOffsetAndReformat("99365", -365, customFormatters));
+    assertEquals("00001", provider.applyOffsetAndReformat("99365", 1, customFormatters));
+  }
+
+  @Test
+  public void testApplyOffsetAndReformat_customError() {
+    DateTimeConsistentShiftMaskingProviderConfig config =
+        new DateTimeConsistentShiftMaskingProviderConfig();
+    config.setPatientIdentifierPath("/id");
+    config.setUnexpectedInputHandling(UnexpectedMaskingInputHandler.MESSAGE);
+    config.setUnexpectedInputReturnMessage("Bad");
+    config.setCustomFormats(
+        Arrays.asList("yyyy-MM-dd'T'HH:mm:ssXXX'['VV']'", "MM-dd-yy", "yyyy-MM-dd'T'HH:mm:ss z", "MMDDD"));
+    DateTimeConsistentShiftMaskingProvider provider =
+        new DateTimeConsistentShiftMaskingProvider(config, null);
+
+    verifyStandardReplacements(provider, "Bad");
+
+    List<DateTimeFormatter> customFormatters = provider.buildCustomFormatters();
+
+    try {
+      provider.applyOffsetAndReformat("10333", -1, customFormatters);
+      fail("expected exception");
+    } catch (BadFormatterException e) {
+      assertEquals("Insufficient date information from date format pattern `MMDDD`",
+          e.getMessage());
+    }
   }
 
   @Test
@@ -366,11 +404,13 @@ public class DateTimeConsistentShiftMaskingProviderTest implements MaskingProvid
     verifyRepeatable(provider, null);
     verifyRepeatable(provider, "");
     verifyRepeatable(provider, "   ");
-    long value1 = verifyRepeatable(provider, "patient1");
-    assertEquals(value1, verifyRepeatable(provider, " PATIENT1 "));
+    
+    // should be same result on any computer, any time    
+    assertEquals(8001756538252770565L, verifyRepeatable(provider, "patient1"));
+    assertEquals(8001756538252770565L, verifyRepeatable(provider, " PATIENT1 "));
     String input = " now is the time to check special chars !@#$%^&*()-_+=/\\ ";
-    long value2 = verifyRepeatable(provider, input);
-    assertEquals(value2, verifyRepeatable(provider, input.trim().toUpperCase()));
+    assertEquals(7539049058547281928L, verifyRepeatable(provider, input));
+    assertEquals(7539049058547281928L, verifyRepeatable(provider, input.trim().toUpperCase()));
   }
 
   private long verifyRepeatable(DateTimeConsistentShiftMaskingProvider provider, String input) {
@@ -455,7 +495,7 @@ public class DateTimeConsistentShiftMaskingProviderTest implements MaskingProvid
         new MaskingActionInputIdentifier(provider, target, parent, "three", "type", "id", root);
 
     try {
-      provider.generateReplacement(identifier);
+      provider.generateReplacement(identifier, null);
       fail("expected exception");
     } catch (PrivacyProviderInvalidInputException e) {
       assertTrue(e.getMessage().contains("name-XX"));
@@ -471,7 +511,7 @@ public class DateTimeConsistentShiftMaskingProviderTest implements MaskingProvid
         new MaskingActionInputIdentifier(provider, target, parent, "three", "type", "id", root);
 
     try {
-      provider.generateReplacement(identifier);
+      provider.generateReplacement(identifier, null);
       fail("expected exception");
     } catch (PrivacyProviderInvalidInputException e) {
       assertTrue(e.getMessage().contains("name-X2"));
@@ -482,7 +522,7 @@ public class DateTimeConsistentShiftMaskingProviderTest implements MaskingProvid
     identifier =
         new MaskingActionInputIdentifier(provider, target, parent, "three", "type", "id", root);
     try {
-      provider.generateReplacement(identifier);
+      provider.generateReplacement(identifier, null);
       fail("expected exception");
     } catch (PrivacyProviderInvalidInputException e) {
       assertTrue(e.getMessage().contains("name-X2"));

--- a/ipv-utils/src/main/java/com/ibm/whc/deid/utils/log/LogCodes.java
+++ b/ipv-utils/src/main/java/com/ibm/whc/deid/utils/log/LogCodes.java
@@ -37,6 +37,7 @@ public interface LogCodes {
   public static final String WPH1022W = "WPH1022W";
   public static final String WPH1023E = "WPH1023E";
   public static final String WPH1024E = "WPH1024E";
+  public static final String WPH1025E = "WPH1025E";
   public static final String WPH1100E = "WPH1100E";
   public static final String WPH2000I = "WPH2000I";
   public static final String WPH2001W = "WPH2001W";

--- a/ipv-utils/src/main/resources/logCodes.properties
+++ b/ipv-utils/src/main/resources/logCodes.properties
@@ -29,6 +29,7 @@ WPH1021W = Multiple resources of the same type were loaded with the same key `{0
 WPH1022W = Multiple resources of the same type were loaded with the same localization code `{0}` and the same key `{1}`.
 WPH1023E = Invalid values were encountered while reading record {0} from {1}: {2}
 WPH1024E = The input value `{0}` is not recognized or is in the wrong format for rule {1}.  Processing is stopping as directed by configuration.
+WPH1025E = Insufficient date information from date format pattern `{0}`
 
 #
 # IPV-jsonpath

--- a/whc-shared/src/main/java/com/ibm/whc/deid/shared/pojo/config/masking/DateTimeConsistentShiftMaskingProviderConfig.java
+++ b/whc-shared/src/main/java/com/ibm/whc/deid/shared/pojo/config/masking/DateTimeConsistentShiftMaskingProviderConfig.java
@@ -9,6 +9,7 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.util.List;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.ibm.whc.deid.shared.pojo.config.DeidMaskingConfig;
 import com.ibm.whc.deid.shared.pojo.masking.MaskingProviderType;
@@ -28,21 +29,32 @@ public class DateTimeConsistentShiftMaskingProviderConfig extends MaskingProvide
     /**
      * The shifted value is before the original value.
      */
-    before,
+    BEFORE("before"),
 
     /**
      * The shifted value can be before or after the original value.
      */
-    beforeOrAfter,
+    BEFORE_OR_AFTER("beforeOrAfter"),
 
     /**
      * The shifted value is after the original value.
      */
-    after
+    AFTER("after");
+
+    private String value;
+
+    private DateShiftDirection(String val) {
+      this.value = val;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
   }
 
   public static final DateShiftDirection DEFAULT_DATE_SHIFT_DIRECTION =
-      DateShiftDirection.beforeOrAfter;
+      DateShiftDirection.BEFORE_OR_AFTER;
 
   private List<String> customFormats = null;
   private int dateShiftMinimumDays = 1;

--- a/whc-shared/src/test/java/com/ibm/whc/deid/shared/pojo/config/masking/DateTimeConsistentShiftMaskingProviderConfigTest.java
+++ b/whc-shared/src/test/java/com/ibm/whc/deid/shared/pojo/config/masking/DateTimeConsistentShiftMaskingProviderConfigTest.java
@@ -138,11 +138,11 @@ public class DateTimeConsistentShiftMaskingProviderConfigTest {
   public void testSetters() {
     DateTimeConsistentShiftMaskingProviderConfig config =
         new DateTimeConsistentShiftMaskingProviderConfig();
-    assertEquals(DateShiftDirection.beforeOrAfter, config.getDateShiftDirection());
-    config.setDateShiftDirection(DateShiftDirection.after);
-    assertEquals(DateShiftDirection.after, config.getDateShiftDirection());
+    assertEquals(DateShiftDirection.BEFORE_OR_AFTER, config.getDateShiftDirection());
+    config.setDateShiftDirection(DateShiftDirection.AFTER);
+    assertEquals(DateShiftDirection.AFTER, config.getDateShiftDirection());
     config.setDateShiftDirection(null);
-    assertEquals(DateShiftDirection.beforeOrAfter, config.getDateShiftDirection());
+    assertEquals(DateShiftDirection.BEFORE_OR_AFTER, config.getDateShiftDirection());
   }
 
   @Test
@@ -178,11 +178,11 @@ public class DateTimeConsistentShiftMaskingProviderConfigTest {
     assertTrue(config.equals(other));
     assertEquals(config.hashCode(), other.hashCode());
 
-    config.setDateShiftDirection(DateShiftDirection.before);
+    config.setDateShiftDirection(DateShiftDirection.BEFORE);
     assertFalse(config.equals(other));
-    other.setDateShiftDirection(DateShiftDirection.after);
+    other.setDateShiftDirection(DateShiftDirection.AFTER);
     assertFalse(config.equals(other));
-    other.setDateShiftDirection(DateShiftDirection.before);
+    other.setDateShiftDirection(DateShiftDirection.BEFORE);
     assertTrue(config.equals(other));
     assertEquals(config.hashCode(), other.hashCode());
 


### PR DESCRIPTION
- move non-serializable members
- better error message if insufficient custom pattern
- use uppercase for enum constants